### PR TITLE
fix with_items: barword_variable issue

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,5 +14,5 @@
   apt:
     pkg: "{{item}}"
     state: present
-  with_items: vim_extras
+  with_items: "{{vim_extras}}"
   when: vim_extras|length > 0


### PR DESCRIPTION
This fixes the with_items: barword_variable issue since ansible 2.2.0.0 treats it as an error not a deprecation