### PR TITLE
fix bare variables warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,5 +14,5 @@
   apt:
     pkg: "{{item}}"
     state: present
-  with_items: vim_extras
+  with_items: "{{ vim_extras }}"
   when: vim_extras|length > 0


### PR DESCRIPTION
Under ansible 2.0.x this will give a warning:

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your
playbooks so that the environment value uses the full variable syntax
('{{vim_extras}}').
This feature will be removed in a future release.
```

I can confirm this is indeed broken in 2.2.x